### PR TITLE
US029 - Role Ordering

### DIFF
--- a/src/controller/jobRoleController.ts
+++ b/src/controller/jobRoleController.ts
@@ -56,6 +56,12 @@ export namespace JobRoles {
         const capabilityOrder = req.query?.capabilityOrder as string;
         const bandOrder = req.query?.bandOrder as string;
         
+        if (req.query && Object.keys(req.query).length > 1) {
+            const first = Object.keys(req.query)[0];
+            res.redirect(`/job-roles?${new URLSearchParams({ [first]: req.query[first] as string }).toString()}`);
+            return;
+        }
+        
         try {
             const jobRoles: JobRole[] = await jobRoleService.getJobRoles(req.session.token);
             if (nameOrder) {
@@ -69,7 +75,7 @@ export namespace JobRoles {
             res.locals.getSortQueryString = (property: string) => { return getSortQueryString(req, property) };
             res.locals.getSortHTMLSymbol = (property: string) => { return getSortHTMLSymbol(req, property) };
         } catch (e) {
-            res.locals.errorMessage = e;
+            res.locals.errorMessage = e.message;
         }
 
         res.render("job-roles");

--- a/src/controller/jobRoleController.ts
+++ b/src/controller/jobRoleController.ts
@@ -2,11 +2,72 @@ import type { Request, Response } from "express";
 import type { JobRole } from "../model/jobRole";
 import { jobRoleService } from "../service/jobRoleService";
 
+
+const orderJobRolesByProperty = (list: JobRole[], property: keyof JobRole, asc: boolean) => {
+    if (typeof list[0][property] === "string") {
+        list.sort((a, b) => asc ?
+                (a[property] as string).localeCompare(b[property] as string) :
+                (b[property] as string).localeCompare(a[property] as string)
+        );
+    }
+};
+
+const orderJobRolesByCapability = (list: JobRole[], asc: boolean) => {
+    list.sort((a, b) => asc ?
+            (a.capability.capabilityName).localeCompare(b.capability.capabilityName) :
+            (b.capability.capabilityName).localeCompare(a.capability.capabilityName)
+    );
+};
+
+const orderJobRolesByBand = (list: JobRole[], asc: boolean) => {
+    list.sort((a, b) => asc ?
+            (a.band.bandName).localeCompare(b.band.bandName) :
+            (b.band.bandName).localeCompare(a.band.bandName)
+    );
+};
+
+const getSortQueryString = (req: Request, property: string) => {
+    const query = req.query[property] as string;
+    
+    if (query === "asc") {
+        return `?${new URLSearchParams({ [property]: "desc" }).toString()}`;
+    } else if (query === undefined) {
+        return `?${new URLSearchParams({ [property]: "asc" }).toString()}`;
+    } 
+
+    return '';
+};
+
+const getSortHTMLSymbol = (req: Request, property: string) => {
+    const query = req.query[property] as string;
+
+    if (query === "asc") {
+        return "&uarr;";
+    } else if (query === "desc") {
+        return "&darr;";
+    }
+
+    return '';
+};
+
 export namespace JobRoles {
     export async function get(req: Request, res: Response): Promise<void> {
+        const nameOrder = req.query?.nameOrder as string;
+        const capabilityOrder = req.query?.capabilityOrder as string;
+        const bandOrder = req.query?.bandOrder as string;
+        
         try {
             const jobRoles: JobRole[] = await jobRoleService.getJobRoles(req.session.token);
+            if (nameOrder) {
+                orderJobRolesByProperty(jobRoles, "jobRoleName", nameOrder === "asc");
+            } else if (capabilityOrder) {
+                orderJobRolesByCapability(jobRoles, capabilityOrder === "asc");
+            } else if (bandOrder) {
+                orderJobRolesByBand(jobRoles, bandOrder === "asc");
+            }
             res.locals.jobRoles = jobRoles;
+            res.locals.getSortQueryString = (property: string) => { return getSortQueryString(req, property) };
+            res.locals.getSortHTMLSymbol = (property: string) => { return getSortHTMLSymbol(req, property) };
         } catch (e) {
             res.locals.errorMessage = e;
         }

--- a/static/styles/globalstyles.css
+++ b/static/styles/globalstyles.css
@@ -70,6 +70,10 @@ a, a:visited {
     text-decoration: none;
 }
 
+th > a, th > a:visited {
+    color: black;
+}
+
 .btn-primary {
     background-color: var(--kainos-blue);
     border-color: var(--kainos-blue);

--- a/test/unit/controller/jobRoleControllerTest.ts
+++ b/test/unit/controller/jobRoleControllerTest.ts
@@ -1,87 +1,228 @@
-import chai from 'chai';
-import request from 'supertest'
-import express from 'express';
 import sinon from 'sinon';
 import { jobRoleService } from '../../../src/service/jobRoleService';
-import router from '../../../src/router';
-import expressSession from 'express-session';
+import { JobRoles } from '../../../src/controller/jobRoleController';
+import chai from 'chai';
 
 const expect = chai.expect;
 
-const app = express();
-app.use(express.urlencoded({ extended: false }));
-app.use(express.json());
+const bands = { 
+    associate: {
+        bandID: 1, 
+        bandName: 'Associate' 
+    },
+    trainee: {
+        bandID: 2,
+        bandName: 'Trainee'
+    }
+};
+const capabilities = {
+    thinking: {
+        capabilityID: 1,
+        capabilityName: 'Thinking'
+    },
+    doing: {
+        capabilityID: 2,
+        capabilityName: 'Doing'
+    }
+}
 
-app.use(expressSession({ secret: "test", resave: true, cookie: { maxAge: 1000 * 60 * 60 * 24 } }))
+// ID | Name             | Band      | Capability 
+// ------------------------------------------
+// 1  | Thinker          | Associate | Thinking
+// 2  | Lead Thinker     | Associate | Thinking
+// 3  | Trainee Thinker  | Trainee   | Thinking
+// 4  | Doer             | Associate | Doing
+// 5  | Lead Doer        | Associate | Doing
+// 6  | Trainee Doer     | Trainee   | Doing
+const jobRoles = [
+    {
+        jobRoleID: 1,
+        jobRoleName: 'Thinker',
+        jobSpecSummary: 'Thinks about stuff',
+        band: bands.associate,
+        capability: capabilities.thinking,
+        responsibilities: 'Responsible for thoughts',
+        sharePoint: 'https://sharepoint.com/thinker'
+    },
+    {
+        jobRoleID: 2,
+        jobRoleName: 'Lead Thinker',        
+        jobSpecSummary: 'Trains other people to do some thinking',
+        band: bands.associate,
+        capability: capabilities.thinking,
+        responsibilities: 'Responsible for thoughts',        
+        sharePoint: 'https://sharepoint.com/lead-thinker'
+    },
+    {
+        jobRoleID: 3,
+        jobRoleName: 'Trainee Thinker',
+        jobSpecSummary: 'Thinks about stuff under supervision',
+        band: bands.trainee,
+        capability: capabilities.thinking,
+        responsibilities: 'Responsible for thoughts',
+        sharePoint: 'https://sharepoint.com/trainee-thinker'
+    },
+    {
+        jobRoleID: 4,
+        jobRoleName: 'Doer',        
+        jobSpecSummary: 'Does stuff',
+        band: bands.associate,
+        capability: capabilities.doing,
+        responsibilities: 'Responsible for doing stuff',
+        sharePoint: 'https://sharepoint.com/doer'
+    },
+    {
+        jobRoleID: 5,
+        jobRoleName: 'Lead Doer',
+        jobSpecSummary: 'Trains other people to do stuff',
+        band: bands.associate,
+        capability: capabilities.doing,
+        responsibilities: 'Responsible for doing stuff',
+        sharePoint: 'https://sharepoint.com/lead-doer'
+    },
+    {
+        jobRoleID: 6,
+        jobRoleName: 'Trainee Doer',
+        jobSpecSummary: 'Does stuff under supervision',
+        band: bands.trainee,
+        capability: capabilities.doing,
+        responsibilities: 'Responsible for doing stuff',
+        sharePoint: 'https://sharepoint.com/trainee-doer'
+    }
+]
 
-app.all('*', (req, res, next) => {
-    req.session.token = 'test';
-    req.session.user = {
-        userID: 1,
-        email: 'test@test.com', 
-        role: { 
-            roleID: 1, 
-            roleName: 'Admin' 
-        }
-    };
+const callAndAssertJobRolesGetWithQuery = async (parameter: string, order: string): Promise<any> => {
+    sinon.stub(jobRoleService, 'getJobRoles').resolves([...jobRoles]);
+    
+    const req = { session: {}, query: { [parameter]: order } as any };
+    const res = { render: sinon.spy(), locals: { 
+        jobRoles: undefined as any, 
+        getSortQueryString: undefined as any, 
+        getSortHTMLSymbol: undefined as any 
+    }};
 
-    next();
-});
+    await JobRoles.get(req as any, res as any);
 
-app.use(router);
+    expect(res.render.calledOnce).to.be.true;
+    expect(res.render.calledWith('job-roles')).to.be.true;
+    
+    assertGenerateQueryStringAndHTMLSymbol(res, parameter, order);
+    
+    return { req, res };
+}
+
+const assertGenerateQueryStringAndHTMLSymbol = (res: any, parameter: string, order: string) => {
+    expect(res.locals.getSortQueryString).to.be.a('function');
+    expect(res.locals.getSortHTMLSymbol).to.be.a('function');
+
+    const queryString = res.locals.getSortQueryString(parameter);
+    if (order === 'asc') {
+        expect(queryString).to.equal(`?${parameter}=desc`);
+    } else if (order === 'desc') {
+        expect(queryString).to.equal('');
+    } else {
+        expect(queryString).to.equal(`?${parameter}=asc`);
+    }
+    
+    const htmlSymbol = res.locals.getSortHTMLSymbol(parameter);
+    if (order === 'asc') {
+        expect(htmlSymbol).to.equal('&uarr;');
+    } else if (order === 'desc') {
+        expect(htmlSymbol).to.equal('&darr;');
+    } else {
+        expect(htmlSymbol).to.equal('');
+    }
+}
+
+const assertJobRoleOrder = (res: any, expectedOrder: number[]) => {
+    expectedOrder.forEach((jobRoleID: number, index: number) => {
+        expect(res.locals.jobRoles[index].jobRoleID).to.equal(jobRoleID);
+    });
+}
 
 describe('jobRoleController', () => {
     beforeEach(() => {
         sinon.restore();
     });
-
+    
     it('should render job-roles.html template with no job roles', async () => {
         sinon.stub(jobRoleService, 'getJobRoles').resolves([]);
 
-        request(app)
-            .get('/job-roles')
-            .expect(200)
-            .expect('Content-Type', 'text/html; charset=utf-8')
-            .end((err, res) => {
-                expect(res.text).to.contain('<h1>Job Roles</h1>');
-            }
-        );
+        const req = { session: {} as any};
+        const res = { render: sinon.spy(), locals: { jobRoles: undefined as any } };
+
+        await JobRoles.get(req as any, res as any);
+
+        expect(res.render.calledOnce).to.be.true;
+        expect(res.render.calledWith('job-roles')).to.be.true;
+        expect(res.locals.jobRoles).to.deep.equal([]); 
     });
     
     it('should render job-roles.html template with job roles', async () => {
-        sinon.stub(jobRoleService, 'getJobRoles').resolves([{ 
-            jobRoleID: 1,
-            jobRoleName: 'Test job role',
-            jobSpecSummary: 'Test summary',
-            band: { bandID: 1, bandName: 'Test band' },
-            capability: { capabilityID: 2, capabilityName: 'Test capability' },
-            responsibilities: 'Test responsibilities',
-            sharePoint: 'Test sharepoint'
-        }]);
+        sinon.stub(jobRoleService, 'getJobRoles').resolves(jobRoles);
 
-        request(app)
-            .get('/job-roles')
-            .expect(200)
-            .expect('Content-Type', 'text/html; charset=utf-8')
-            .end((err, res) => {
-                expect(res.text).to.contain('<h1>Job Roles</h1>');
-                expect(res.text).to.contain('Test job role');
-            }
-        );
+        const req = { session: {} as any};
+        const res = { render: sinon.spy(), locals: { jobRoles: undefined as any } };
+
+        await JobRoles.get(req as any, res as any);
+
+        expect(res.render.calledOnce).to.be.true;
+        expect(res.render.calledWith('job-roles')).to.be.true;
+        expect(res.locals.jobRoles).to.deep.equal(jobRoles);
     });
     
     it('should render job-roles.html template with error message', async () => {
-        sinon.stub(jobRoleService, 'getJobRoles').throws(new Error('Test error'));
+        sinon.stub(jobRoleService, 'getJobRoles').rejects(new Error('Test error'));
 
-        request(app)
-            .get('/job-roles')
-            .expect(200)
-            .expect('Content-Type', 'text/html; charset=utf-8')
-            .end((err, res) => {
-                expect(res.text).to.contain('<h1>Job Roles</h1>');
-                expect(res.text).to.contain('Test error');
-            }
-        );
+        const req = { session: {} as any};
+        const res = { render: sinon.spy(), locals: { jobRoles: undefined as any, errorMessage: undefined as any } };
+
+        await JobRoles.get(req as any, res as any);
+
+        expect(res.render.calledOnce).to.be.true;
+        expect(res.render.calledWith('job-roles')).to.be.true;
+        expect(res.locals.jobRoles).to.be.undefined;
+        expect(res.locals.errorMessage).to.equal('Test error');
+    });
+    
+    it('should render job-roles.html template with job roles ordered by name ascending', async () => {
+        const { _, res } = await callAndAssertJobRolesGetWithQuery('nameOrder', 'asc');
+        assertJobRoleOrder(res, [4, 5, 2, 1, 6, 3]);
+    });
+    
+    it('should render job-roles.html template with job roles ordered by name descending', async () => {
+        const { _, res } = await callAndAssertJobRolesGetWithQuery('nameOrder', 'desc');
+        assertJobRoleOrder(res, [3, 6, 1, 2, 5, 4]);
+    });
+
+    it('should render job-roles.html template with job roles ordered by capability ascending', async () => {
+        const { _, res } = await callAndAssertJobRolesGetWithQuery('capabilityOrder', 'asc');
+        assertJobRoleOrder(res, [4, 5, 6, 1, 2, 3]);
+    });
+    
+    it('should render job-roles.html template with job roles ordered by capability descending', async () => {
+        const { _, res } = await callAndAssertJobRolesGetWithQuery('capabilityOrder', 'desc');
+        assertJobRoleOrder(res, [1, 2, 3, 4, 5, 6]);
+    });
+
+    it('should render job-roles.html template with job roles ordered by band ascending', async () => {
+        const { _, res } = await callAndAssertJobRolesGetWithQuery('bandOrder', 'asc');
+        assertJobRoleOrder(res, [1, 2, 4, 5, 3, 6]);
+    });
+    
+    it('should render job-roles.html template with job roles ordered by band descending', async () => {
+        const { _, res } = await callAndAssertJobRolesGetWithQuery('bandOrder', 'desc');
+        assertJobRoleOrder(res, [3, 6, 1, 2, 4, 5]);
+    });
+    
+    it('should redirect to /job-roles with one parameter if multiple parameters are passed', async () => {
+        const req = { session: {}, query: { nameOrder: 'asc', capabilityOrder: 'asc' } as any };
+        const res = { redirect: sinon.spy() };
+
+        await JobRoles.get(req as any, res as any);
+
+        expect(res.redirect.calledOnce).to.be.true;
+        expect(res.redirect.calledWith('/job-roles?nameOrder=asc')).to.be.true;
     });
 
 });

--- a/views/job-roles.html
+++ b/views/job-roles.html
@@ -8,9 +8,9 @@
     <p>Current job roles at Kainos</p>
     <table id="job-roles-table">
         <tr>
-            <th>Role</th>
-            <th>Band</th>
-            <th>Capability</th>
+            <th><a href="/job-roles{{ getSortQueryString('nameOrder') }}">Name {{ getSortHTMLSymbol('nameOrder')|safe }}</a></th>
+            <th><a href="/job-roles{{ getSortQueryString('bandOrder') }}">Band {{ getSortHTMLSymbol('bandOrder')|safe }}</a></th>
+            <th><a href="/job-roles{{ getSortQueryString('capabilityOrder') }}">Capability {{ getSortHTMLSymbol('capabilityOrder')|safe }}</a></th>
             <th>Actions</th>
         </tr>
         {% for jobRole in jobRoles %}


### PR DESCRIPTION
This PR adds clickable headers on the job roles table to sort it. It does not use any client side JavaScript.

![Screenshot 2023-09-25 at 11 57 22](https://github.com/anthony-raybould/bham1-front-end/assets/13875753/f329f698-c0f0-48f9-b023-bac0a34b82b8)
![image](https://github.com/anthony-raybould/bham1-front-end/assets/13875753/ba85fb88-a703-4d0c-b71d-b956bde75fbd)
![image](https://github.com/anthony-raybould/bham1-front-end/assets/13875753/c9e5f0b5-7a17-4abb-9eb4-ce5327830493)

